### PR TITLE
fix: 本番サイトでのみ、新規登録フォームのユーザー名を空欄にして、フォーカスを移動してもエラーにならない #228

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -46,6 +46,7 @@ export const LoginForm: FC<LoginFormProps> = ({ setForm, onClose }) => {
     handlePasswordChange,
     handleEmailBlur,
     handlePasswordBlur,
+    handleEmailFocus,
   } = useForm()
 
   return (
@@ -61,6 +62,7 @@ export const LoginForm: FC<LoginFormProps> = ({ setForm, onClose }) => {
           value={email}
           onChange={handleEmailChange}
           onBlur={handleEmailBlur}
+          onFocus={handleEmailFocus}
           error={emailError}
         />
         <InputField

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -60,6 +60,7 @@ export const SignUpForm: FC<SignUpFormProps> = ({ setForm, onClose }) => {
     handleEmailBlur,
     handlePasswordBlur,
     handlePasswordConfirmBlur,
+    handleUsernamelFocus,
     handleEmailFocus,
   } = useForm()
 
@@ -96,6 +97,7 @@ export const SignUpForm: FC<SignUpFormProps> = ({ setForm, onClose }) => {
           value={username}
           onChange={handleUsernameChange}
           onBlur={handleUsernameBlur}
+          onFocus={handleUsernamelFocus}
           error={usernameError}
           isFocus={true}
         />

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -242,6 +242,9 @@ export const useForm = () => {
   const handleTripMemoBlur = () => setTripMemoError(validateTripMemo(tripMemo))
   const handleSpotMemoBlur = () => setSpotMemoError(validateSpotMemo(spotMemo))
 
+  const handleUsernamelFocus = () => {
+    setUsernameTouched(true)
+  }
   const handleEmailFocus = () => {
     setEmailTouched(true)
   }
@@ -310,6 +313,7 @@ export const useForm = () => {
     handleCostBlur,
     handleTripMemoBlur,
     handleSpotMemoBlur,
+    handleUsernamelFocus,
     handleEmailFocus,
   }
 }


### PR DESCRIPTION
close #228 