### PR TITLE
fix: 本番サイトでのみ、旅行プラン作成フォームの旅行タイトルを空欄にして、フォーカスを移動してもエラーにならない #234

### DIFF
--- a/src/components/CreateTripForm.tsx
+++ b/src/components/CreateTripForm.tsx
@@ -62,6 +62,7 @@ export const CreateTripForm: FC<CreateTripFormProps> = ({ onClose }) => {
     handleStartDateChange,
     handleEndDateChange,
     handleTripTitleBlur,
+    handleTripTitleFocus,
   } = useForm()
 
   return (
@@ -75,6 +76,7 @@ export const CreateTripForm: FC<CreateTripFormProps> = ({ onClose }) => {
         value={tripTitle}
         onChange={handleTripTitleChange}
         onBlur={handleTripTitleBlur}
+        onFocus={handleTripTitleFocus}
         error={tripTitleError}
       />
       <SelectField

--- a/src/components/SpotForm.tsx
+++ b/src/components/SpotForm.tsx
@@ -61,6 +61,7 @@ export const SpotForm: FC<SpotFormProps> = ({ onClose, mode, date }) => {
     handleEndTimeBlur,
     handleCostBlur,
     handleSpotMemoBlur,
+    handleSpotNameFocus,
   } = useForm()
 
   const selectedTripItem = TRIP_DESTINATION_ITEMS.find(
@@ -180,6 +181,7 @@ export const SpotForm: FC<SpotFormProps> = ({ onClose, mode, date }) => {
         value={spotName}
         onChange={handleSpotNameChange}
         onBlur={handleSpotNameBlur}
+        onFocus={handleSpotNameFocus}
         error={spotNameError}
       />
 

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -248,6 +248,12 @@ export const useForm = () => {
   const handleEmailFocus = () => {
     setEmailTouched(true)
   }
+  const handleTripTitleFocus = () => {
+    setTripTitleTouched(true)
+  }
+  const handleSpotNameFocus = () => {
+    setSpotNameTouched(true)
+  }
 
   return {
     username,
@@ -315,5 +321,7 @@ export const useForm = () => {
     handleSpotMemoBlur,
     handleUsernamelFocus,
     handleEmailFocus,
+    handleTripTitleFocus,
+    handleSpotNameFocus,
   }
 }


### PR DESCRIPTION
close #234 