### PR TITLE
fix: 旅行一覧画面を表示すると、一瞬「検索条件に一致する旅行プランが見つかりませんでした。」と表示される #286

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,9 @@ export default function Home() {
   const itemsPerPage = 12
   const pagesVisited = pageNumber * itemsPerPage
 
-  const [filteredData, setFilteredData] = useState<DbTripData[]>([])
+  const [filteredData, setFilteredData] = useState<DbTripData[]>(
+    dbTripsData || []
+  )
 
   useEffect(() => {
     setPageNumber(0)


### PR DESCRIPTION
close #286 