### PR TITLE
Potential fix for code scanning alert no. 51: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI/CD
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/keynyaan/hayabusatrip-frontend/security/code-scanning/51](https://github.com/keynyaan/hayabusatrip-frontend/security/code-scanning/51)

To fix the problem, add a `permissions` block to explicitly restrict the GitHub Actions `GITHUB_TOKEN` to minimal necessary privileges. This is typically placed at the top level of the workflow file (recommended, applies to all jobs unless overridden), or can be set per job. Since none of the jobs require write access to the repo, `permissions: contents: read` is the minimal and correct setting. This should be added after the workflow `name:` and before the `on:` block for clarity and to cover all jobs.

**Detailed fix:**  
- Edit the `.github/workflows/ci.yml` file.
- After the `name: CI/CD` line and before the `on:` block, insert:
  ```yaml
  permissions:
    contents: read
  ```
- This ensures that the workflow and all jobs within only have read access to repository contents.

No additional imports, method definitions, or other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
